### PR TITLE
Fix for write corruption and update to work with PhysFS 3.x

### DIFF
--- a/include/physfs.hpp
+++ b/include/physfs.hpp
@@ -36,7 +36,7 @@ typedef PHYSFS_sint64 sint64;
 
 typedef PHYSFS_StringCallback StringCallback;
 
-typedef PHYSFS_EnumFilesCallback EnumFilesCallback;
+typedef PHYSFS_EnumerateCallback EnumFilesCallback;
 
 typedef PHYSFS_Version Version;
 
@@ -46,38 +46,55 @@ typedef PHYSFS_ArchiveInfo ArchiveInfo;
 
 typedef std::vector<ArchiveInfo> ArchiveInfoList;
 
+typedef PHYSFS_Stat Stat;
+
 typedef uint64 size_t;
 
 class base_fstream {
 protected:
-	PHYSFS_File * const file;
+	PHYSFS_File* file;
 public:
-	base_fstream(PHYSFS_File * file);
+	base_fstream(PHYSFS_File* file);
 	virtual ~base_fstream();
 	size_t length();
+
+	virtual void open(std::string const& filename, mode openMode) = 0;
+	virtual void close();
 };
 
-class ifstream : public base_fstream, public std::istream {
+class ifstream : public base_fstream, public std::istream
+{
 public:
-	ifstream(string const & filename);
+	explicit ifstream(string const& filename);
 	virtual ~ifstream();
+
+	void open(std::string const& filename, mode openMode = READ) override;
+	void close() override;
 };
 
-class ofstream : public base_fstream, public std::ostream {
+class ofstream : public base_fstream, public std::ostream
+{
 public:
-	ofstream(string const & filename, mode writeMode = WRITE);
+	explicit ofstream(string const& filename, mode writeMode = WRITE);
 	virtual ~ofstream();
+
+	void open(std::string const& filename, mode openMode = WRITE) override;
+	void close() override;
 };
 
-class fstream : public base_fstream, public std::iostream {
+class fstream : public base_fstream, public std::iostream
+{
 public:
-	fstream(string const & filename, mode openMode = READ);
+	explicit fstream(string const& filename, mode openMode = READ);
 	virtual ~fstream();
+
+	void open(std::string const& filename, mode openMode = READ) override;
+	void close() override;
 };
 
 Version getLinkedVersion();
 
-void init(char const * argv0);
+void init(char const* argv0);
 
 void deinit();
 
@@ -89,51 +106,53 @@ void permitSymbolicLinks(bool allow);
 
 StringList getCdRomDirs();
 
-void getCdRomDirs(StringCallback callback, void * extra);
+void getCdRomDirs(StringCallback callback, void* extra);
 
 string getBaseDir();
 
-string getUserDir();
+string getPrefDir(const string& org, const string& app);
 
 string getWriteDir();
 
-void setWriteDir(string const & newDir);
-
-void removeFromSearchPath(string const & oldDir);
+void setWriteDir(string const& newDir);
 
 StringList getSearchPath();
 
-void getSearchPath(StringCallback callback, void * extra);
+void getSearchPath(StringCallback callback, void* extra);
 
-void setSaneConfig(string const & orgName, string const & appName, string const & archiveExt, bool includeCdRoms, bool archivesFirst);
+void setSaneConfig(string const& orgName, string const& appName, string const& archiveExt, bool includeCdRoms, bool archivesFirst);
 
-void mkdir(string const & dirName);
+int mkdir(string const& dirName);
 
-void deleteFile(string const & filename);
+int deleteFile(string const& filename);
 
-string getRealDir(string const & filename);
+string getRealDir(string const& filename);
 
-StringList enumerateFiles(string const & directory);
+StringList enumerateFiles(string const& directory);
 
-void enumerateFiles(string const & directory, EnumFilesCallback callback, void * extra);
+int enumerateFiles(string const& directory, EnumFilesCallback callback, void* extra);
 
-bool exists(string const & filename);
+bool exists(string const& filename);
 
-bool isDirectory(string const & filename);
+Stat getStat(string const& filename);
 
-bool isSymbolicLink(string const & filename);
+bool isDirectory(string const& filename);
 
-sint64 getLastModTime(string const & filename);
+bool isSymbolicLink(string const& filename);
+
+sint64 getLastModTime(string const& filename);
 
 bool isInit();
 
 bool symbolicLinksPermitted();
 
-void setAllocator(Allocator const * allocator);
+void setAllocator(Allocator const* allocator);
 
-void mount(string const & newDir, string const & mountPoint, bool appendToPath);
+void mount(string const& newDir, string const& mountPoint, bool appendToPath);
 
-string getMountPoint(string const & dir);
+void unmount(string const& oldDir);
+
+string getMountPoint(string const& dir);
 
 namespace Util {
 
@@ -161,15 +180,15 @@ sint64 swapSBE64(sint64 value);
 
 uint64 swapUBE64(uint64 value);
 
-string utf8FromUcs4(uint32 const * src);
+string utf8FromUcs4(uint32 const* src);
 
-string utf8ToUcs4(char const * src);
+string utf8ToUcs4(char const* src);
 
-string utf8FromUcs2(uint16 const * src);
+string utf8FromUcs2(uint16 const* src);
 
-string utf8ToUcs2(char const * src);
+string utf8ToUcs2(char const* src);
 
-string utf8FromLatin1(char const * src);
+string utf8FromLatin1(char const* src);
 
 }
 

--- a/src/physfs.cpp
+++ b/src/physfs.cpp
@@ -1,6 +1,5 @@
 #include <streambuf>
 #include <string>
-#include <string.h>
 #include <stdexcept>
 #include "physfs.hpp"
 
@@ -9,383 +8,513 @@ using std::ios_base;
 
 namespace PhysFS {
 
-class fbuf : public streambuf {
-private:
-	fbuf(const fbuf & other);
-	fbuf& operator=(const fbuf& other);
-
-	int_type underflow() {
-		if (PHYSFS_eof(file)) {
-			return traits_type::eof();
-		}
-		size_t bytesRead = PHYSFS_read(file, buffer, 1, bufferSize);
-		if (bytesRead < 1) {
-			return traits_type::eof();
-		}
-		setg(buffer, buffer, buffer + bytesRead);
-		return (unsigned char) *gptr();
-	}
-
-	pos_type seekoff(off_type pos, ios_base::seekdir dir, ios_base::openmode mode) {
-		switch (dir) {
-		case std::ios_base::beg:
-			PHYSFS_seek(file, pos);
-			break;
-		case std::ios_base::cur:
-			// subtract characters currently in buffer from seek position
-			PHYSFS_seek(file, (PHYSFS_tell(file) + pos) - (egptr() - gptr()));
-			break;
-		case std::ios_base::end:
-			PHYSFS_seek(file, PHYSFS_fileLength(file) + pos);
-			break;
-		}
-		if (mode & std::ios_base::in) {
-			setg(egptr(), egptr(), egptr());
-		}
-		if (mode & std::ios_base::out) {
-			setp(buffer, buffer);
-		}
-		return PHYSFS_tell(file);
-	}
-
-	pos_type seekpos(pos_type pos, std::ios_base::openmode mode) {
-		PHYSFS_seek(file, pos);
-		if (mode & std::ios_base::in) {
-			setg(egptr(), egptr(), egptr());
-		}
-		if (mode & std::ios_base::out) {
-			setp(buffer, buffer);
-		}
-		return PHYSFS_tell(file);
-	}
-
-	int_type overflow( int_type c = traits_type::eof() ) {
-		if (pptr() == pbase() && c == traits_type::eof()) {
-			return 0; // no-op
-		}
-		if (PHYSFS_write(file, pbase(), pptr() - pbase(), 1) < 1) {
-			return traits_type::eof();
-		}
-		if (c != traits_type::eof()) {
-			if (PHYSFS_write(file, &c, 1, 1) < 1) {
-				return traits_type::eof();
-			}
-		}
-
-		return 0;
-	}
-
-	int sync() {
-		return overflow();
-	}
-
-	char * buffer;
-	size_t const bufferSize;
-protected:
-	PHYSFS_File * const file;
+class fbuf : public streambuf
+{
 public:
-	fbuf(PHYSFS_File * file, std::size_t bufferSize = 2048) : file(file), bufferSize(bufferSize) {
-		buffer = new char[bufferSize];
-		char * end = buffer + bufferSize;
-		setg(end, end, end);
-		setp(buffer, end);
-	}
+    fbuf(const fbuf& other) = delete;
+    fbuf& operator=(const fbuf& other) = delete;
 
-	~fbuf() {
-		sync();
-		delete [] buffer;
-	}
+private:
+    int_type underflow() override
+    {
+        if (PHYSFS_eof(file)) 
+        {
+            return traits_type::eof();
+        }
+
+        const auto bytesRead = PHYSFS_readBytes(file, buffer, bufferSize);
+
+        if (bytesRead < 1) {
+            return traits_type::eof();
+        }
+        setg(buffer, buffer, buffer + bytesRead);
+        return (unsigned char)*gptr();
+    }
+
+    pos_type seekoff(off_type pos, ios_base::seekdir dir, ios_base::openmode mode) override
+    {
+        switch (dir)
+        {
+        case std::ios_base::beg:
+            PHYSFS_seek(file, pos);
+            break;
+        case std::ios_base::cur:
+            // subtract characters currently in buffer from seek position
+            PHYSFS_seek(file, (PHYSFS_tell(file) + pos) - (egptr() - gptr()));
+            break;
+        case std::ios_base::end:
+            PHYSFS_seek(file, PHYSFS_fileLength(file) + pos);
+            break;
+        default:
+            break;
+        }
+
+        if (mode & std::ios_base::in) 
+        {
+            setg(egptr(), egptr(), egptr());
+        }
+
+        if (mode & std::ios_base::out) 
+        {
+            setp(buffer, buffer);
+        }
+        return PHYSFS_tell(file);
+    }
+
+    pos_type seekpos(pos_type pos, std::ios_base::openmode mode) override
+    {
+        PHYSFS_seek(file, pos);
+        if (mode & std::ios_base::in) 
+        {
+            setg(egptr(), egptr(), egptr());
+        }
+
+        if (mode & std::ios_base::out) 
+        {
+            setp(buffer, buffer);
+        }
+
+        return PHYSFS_tell(file);
+    }
+
+    int_type overflow(int_type c = traits_type::eof()) override
+    {
+        // Write buffer
+        if (flush() < 0)
+        {
+            return traits_type::eof();
+        }
+
+        setp(buffer, buffer + bufferSize); // reset the put pointers
+
+        if (c != traits_type::eof()) 
+        {
+            *pptr() = (char)c; // Add the overflow character to the put buffer
+            pbump(1); // increment the put pointer by one
+        }
+
+        return c;
+    }
+
+    int sync() override
+    {
+        const auto result = flush();
+        setp(buffer, buffer + bufferSize); // reset the put pointers
+
+        return result;
+    }
+
+    int flush() const
+    {
+        const auto len = pptr() - pbase();
+        if (len == 0)
+        {
+            return 0;  // nothing to do
+        }
+
+        if (PHYSFS_writeBytes(file, pbase(), len) < len)
+        {
+            return -1;
+        }
+
+        return 0;
+    }
+
+    char* buffer;
+    size_t const bufferSize;
+
+protected:
+    PHYSFS_File* const file;
+
+public:
+    explicit fbuf(PHYSFS_File* file, std::size_t bufferSize = 2048) : bufferSize(bufferSize), file(file)
+    {
+        buffer = new char[bufferSize];
+        char* end = buffer + bufferSize;
+        setg(end, end, end);
+        setp(buffer, end);
+    }
+
+    ~fbuf() override
+    {
+        flush();
+        delete[] buffer;
+    }
 };
 
-base_fstream::base_fstream(PHYSFS_File* file) : file(file) {
-    if (file == NULL) {
+base_fstream::base_fstream(PHYSFS_File* file) : file(file)
+{
+    if (file == nullptr) 
+    {
         throw std::invalid_argument("attempted to construct fstream with NULL ptr");
     }
 }
 
-base_fstream::~base_fstream() {
-	PHYSFS_close(file);
+base_fstream::~base_fstream()
+{
+    PHYSFS_close(file);
+    file = nullptr;
 }
 
-PhysFS::size_t base_fstream::length() {
-	return PHYSFS_fileLength(file);
+PhysFS::size_t base_fstream::length()
+{
+    return PHYSFS_fileLength(file);
 }
 
-PHYSFS_File* openWithMode(char const * filename, mode openMode) {
-    PHYSFS_File* file = NULL;
-	switch (openMode) {
-	case WRITE:
-		file = PHYSFS_openWrite(filename);
+PHYSFS_File* openWithMode(char const* filename, mode openMode)
+{
+    PHYSFS_File* file = nullptr;
+    switch (openMode)
+    {
+    case WRITE:
+        file = PHYSFS_openWrite(filename);
         break;
-	case APPEND:
-		file = PHYSFS_openAppend(filename);
+    case APPEND:
+        file = PHYSFS_openAppend(filename);
         break;
-	case READ:
-		file = PHYSFS_openRead(filename);
-	}
-    if (file == NULL) {
+    case READ:
+        file = PHYSFS_openRead(filename);
+    }
+
+    if (file == nullptr)
+    {
         throw std::invalid_argument("file not found: " + std::string(filename));
     }
     return file;
 }
 
-ifstream::ifstream(const string& filename)
-	: base_fstream(openWithMode(filename.c_str(), READ)), std::istream(new fbuf(file)) {}
+void base_fstream::close()
+{
+    if (file)
+    {
+        PHYSFS_close(file);
+        file = nullptr;
+    }
+}
 
-ifstream::~ifstream() {
-	delete rdbuf();
+ifstream::ifstream(const string& filename)
+    : base_fstream(openWithMode(filename.c_str(), READ)), std::istream(new fbuf(file)) {}
+
+ifstream::~ifstream()
+{
+    delete rdbuf();
+}
+
+void ifstream::open(std::string const& filename, mode)
+{
+    delete rdbuf();
+    close();
+    file = openWithMode(filename.c_str(), READ);
+    if (file)
+    {
+        set_rdbuf(new fbuf(file));
+    }
+}
+
+void ifstream::close()
+{
+    base_fstream::close();
+
+    delete rdbuf();
+    set_rdbuf(nullptr);
 }
 
 ofstream::ofstream(const string& filename, mode writeMode)
-	: base_fstream(openWithMode(filename.c_str(), writeMode)), std::ostream(new fbuf(file)) {}
+    : base_fstream(openWithMode(filename.c_str(), writeMode)), std::ostream(new fbuf(file)) {}
 
-ofstream::~ofstream() {
-	delete rdbuf();
+ofstream::~ofstream()
+{
+    delete rdbuf();
+}
+
+void ofstream::open(std::string const& filename, mode openMode)
+{
+    close();
+    file = openWithMode(filename.c_str(), openMode);
+    if (file)
+    {
+        set_rdbuf(new fbuf(file));
+    }
+}
+
+void ofstream::close()
+{
+    base_fstream::close();
+
+    delete rdbuf();
+    set_rdbuf(nullptr);
 }
 
 fstream::fstream(const string& filename, mode openMode)
-	: base_fstream(openWithMode(filename.c_str(), openMode)), std::iostream(new fbuf(file)) {}
+    : base_fstream(openWithMode(filename.c_str(), openMode)), std::iostream(new fbuf(file)) {}
 
-fstream::~fstream() {
-	delete rdbuf();
+fstream::~fstream()
+{
+    delete rdbuf();
+}
+
+void fstream::open(std::string const& filename, mode openMode)
+{
+    close();
+    file = openWithMode(filename.c_str(), openMode);
+    if (file)
+    {
+        set_rdbuf(new fbuf(file));
+    }
+}
+
+void fstream::close()
+{
+    base_fstream::close();
+
+    delete rdbuf();
+    set_rdbuf(nullptr);
 }
 
 Version getLinkedVersion() {
-	Version version;
-	PHYSFS_getLinkedVersion(&version);
-	return version;
+    Version version;
+    PHYSFS_getLinkedVersion(&version);
+    return version;
 }
 
 void init(const char* argv0) {
-	PHYSFS_init(argv0);
+    PHYSFS_init(argv0);
 }
 
 void deinit() {
-	PHYSFS_deinit();
+    PHYSFS_deinit();
 }
 
 ArchiveInfoList supportedArchiveTypes() {
-	ArchiveInfoList list;
-	for (const ArchiveInfo** archiveType = PHYSFS_supportedArchiveTypes(); *archiveType != NULL; archiveType++) {
-		list.push_back(**archiveType);
-	}
-	return list;
+    ArchiveInfoList list;
+    for (const ArchiveInfo** archiveType = PHYSFS_supportedArchiveTypes(); *archiveType != NULL; archiveType++) {
+        list.push_back(**archiveType);
+    }
+    return list;
 }
 
 string getDirSeparator() {
-	return PHYSFS_getDirSeparator();
+    return PHYSFS_getDirSeparator();
 }
 
 void permitSymbolicLinks(bool allow) {
-	PHYSFS_permitSymbolicLinks(allow);
+    PHYSFS_permitSymbolicLinks(allow);
 }
 
 StringList getCdRomDirs() {
-	StringList dirs;
-	char ** dirBegin = PHYSFS_getCdRomDirs();
-	for (char ** dir = dirBegin; *dir != NULL; dir++) {
-		dirs.push_back(*dir);
-	}
-	PHYSFS_freeList(dirBegin);
-	return dirs;
+    StringList dirs;
+    char** dirBegin = PHYSFS_getCdRomDirs();
+    for (char** dir = dirBegin; *dir != NULL; dir++) {
+        dirs.push_back(*dir);
+    }
+    PHYSFS_freeList(dirBegin);
+    return dirs;
 }
 
-void getCdRomDirs(StringCallback callback, void * extra) {
-	PHYSFS_getCdRomDirsCallback(callback, extra);
+void getCdRomDirs(StringCallback callback, void* extra) {
+    PHYSFS_getCdRomDirsCallback(callback, extra);
 }
 
 string getBaseDir() {
-	return PHYSFS_getBaseDir();
+    return PHYSFS_getBaseDir();
 }
 
-string getUserDir() {
-	return PHYSFS_getUserDir();
+string getPrefDir(const string& org, const string& app) {
+    return PHYSFS_getPrefDir(org.c_str(), app.c_str());
 }
 
 string getWriteDir() {
-	return PHYSFS_getWriteDir();
+    return PHYSFS_getWriteDir();
 }
 
 void setWriteDir(const string& newDir) {
-	PHYSFS_setWriteDir(newDir.c_str());
+    PHYSFS_setWriteDir(newDir.c_str());
 }
 
-void removeFromSearchPath(const string& oldDir) {
-	PHYSFS_removeFromSearchPath(oldDir.c_str());
+void unmount(const string& oldDir) {
+    PHYSFS_unmount(oldDir.c_str());
 }
 
 StringList getSearchPath() {
-	StringList pathList;
-	char ** pathBegin = PHYSFS_getSearchPath();
-	for (char ** path = pathBegin; *path != NULL; path++) {
-		pathList.push_back(*path);
-	}
-	PHYSFS_freeList(pathBegin);
-	return pathList;
+    StringList pathList;
+    char** pathBegin = PHYSFS_getSearchPath();
+    for (char** path = pathBegin; *path != NULL; path++) {
+        pathList.push_back(*path);
+    }
+    PHYSFS_freeList(pathBegin);
+    return pathList;
 }
 
-void getSearchPath(StringCallback callback, void * extra) {
-	PHYSFS_getSearchPathCallback(callback, extra);
+void getSearchPath(StringCallback callback, void* extra) {
+    PHYSFS_getSearchPathCallback(callback, extra);
 }
 
 void setSaneConfig(const string& orgName, const string& appName,
-		const string& archiveExt, bool includeCdRoms, bool archivesFirst) {
-	PHYSFS_setSaneConfig(orgName.c_str(), appName.c_str(), archiveExt.c_str(), includeCdRoms, archivesFirst);
+    const string& archiveExt, bool includeCdRoms, bool archivesFirst) {
+    PHYSFS_setSaneConfig(orgName.c_str(), appName.c_str(), archiveExt.c_str(), includeCdRoms, archivesFirst);
 }
 
-void mkdir(const string& dirName) {
-	PHYSFS_mkdir(dirName.c_str());
+int mkdir(const string& dirName) {
+    return PHYSFS_mkdir(dirName.c_str());
 }
 
-void deleteFile(const string& filename) {
-	PHYSFS_delete(filename.c_str());
+int deleteFile(const string& filename) {
+    return PHYSFS_delete(filename.c_str());
 }
 
 string getRealDir(const string& filename) {
-	return PHYSFS_getRealDir(filename.c_str());
+    return PHYSFS_getRealDir(filename.c_str());
 }
 
 StringList enumerateFiles(const string& directory) {
-	StringList files;
-	char ** listBegin = PHYSFS_enumerateFiles(directory.c_str());
-	for (char ** file = listBegin; *file != NULL; file++) {
-		files.push_back(*file);
-	}
-	PHYSFS_freeList(listBegin);
-	return files;
+    StringList files;
+    char** listBegin = PHYSFS_enumerateFiles(directory.c_str());
+    for (char** file = listBegin; *file != NULL; file++) {
+        files.push_back(*file);
+    }
+    PHYSFS_freeList(listBegin);
+    return files;
 }
 
-void enumerateFiles(const string& directory, EnumFilesCallback callback, void * extra) {
-	PHYSFS_enumerateFilesCallback(directory.c_str(), callback, extra);
+int enumerateFiles(string const& directory, EnumFilesCallback callback, void* extra) {
+    return PHYSFS_enumerate(directory.c_str(), callback, extra);
 }
 
 bool exists(const string& filename) {
-	return PHYSFS_exists(filename.c_str());
+    return PHYSFS_exists(filename.c_str());
+}
+
+Stat getStat(const string& filename)
+{
+    Stat stat;
+    PHYSFS_stat(filename.c_str(), &stat);
+
+    return stat;
 }
 
 bool isDirectory(const string& filename) {
-	return PHYSFS_isDirectory(filename.c_str());
+    return (getStat(filename).filetype == PHYSFS_FileType::PHYSFS_FILETYPE_DIRECTORY);
 }
 
 bool isSymbolicLink(const string& filename) {
-	return PHYSFS_isSymbolicLink(filename.c_str());
+    return (getStat(filename).filetype == PHYSFS_FileType::PHYSFS_FILETYPE_SYMLINK);
 }
 
 sint64 getLastModTime(const string& filename) {
-	return PHYSFS_getLastModTime(filename.c_str());
+    return (getStat(filename).modtime);
 }
 
 bool isInit() {
-	return PHYSFS_isInit();
+    return PHYSFS_isInit();
 }
 
 bool symbolicLinksPermitted() {
-	return PHYSFS_symbolicLinksPermitted();
+    return PHYSFS_symbolicLinksPermitted();
 }
 
 void setAllocator(const Allocator* allocator) {
-	PHYSFS_setAllocator(allocator);
+    PHYSFS_setAllocator(allocator);
 }
 
 void mount(const string& newDir, const string& mountPoint, bool appendToPath) {
-	PHYSFS_mount(newDir.c_str(), mountPoint.c_str(), appendToPath);
+    PHYSFS_mount(newDir.c_str(), mountPoint.c_str(), appendToPath);
 }
 
 string getMountPoint(const string& dir) {
-	return PHYSFS_getMountPoint(dir.c_str());
+    return PHYSFS_getMountPoint(dir.c_str());
 }
 
 sint16 Util::swapSLE16(sint16 value) {
-	return PHYSFS_swapSLE16(value);
+    return PHYSFS_swapSLE16(value);
 }
 
 uint16 Util::swapULE16(uint16 value) {
-	return PHYSFS_swapULE16(value);
+    return PHYSFS_swapULE16(value);
 }
 
 sint32 Util::swapSLE32(sint32 value) {
-	return PHYSFS_swapSLE32(value);
+    return PHYSFS_swapSLE32(value);
 }
 
 uint32 Util::swapULE32(uint32 value) {
-	return PHYSFS_swapULE32(value);
+    return PHYSFS_swapULE32(value);
 }
 
 sint64 Util::swapSLE64(sint64 value) {
-	return PHYSFS_swapSLE64(value);
+    return PHYSFS_swapSLE64(value);
 }
 
 uint64 Util::swapULE64(uint64 value) {
-	return PHYSFS_swapULE64(value);
+    return PHYSFS_swapULE64(value);
 }
 
 sint16 Util::swapSBE16(sint16 value) {
-	return PHYSFS_swapSBE16(value);
+    return PHYSFS_swapSBE16(value);
 }
 
 uint16 Util::swapUBE16(uint16 value) {
-	return PHYSFS_swapUBE16(value);
+    return PHYSFS_swapUBE16(value);
 }
 
 sint32 Util::swapSBE32(sint32 value) {
-	return PHYSFS_swapSBE32(value);
+    return PHYSFS_swapSBE32(value);
 }
 
 uint32 Util::swapUBE32(uint32 value) {
-	return PHYSFS_swapUBE32(value);
+    return PHYSFS_swapUBE32(value);
 }
 
 sint64 Util::swapSBE64(sint64 value) {
-	return PHYSFS_swapSBE64(value);
+    return PHYSFS_swapSBE64(value);
 }
 
 uint64 Util::swapUBE64(uint64 value) {
-	return PHYSFS_swapUBE64(value);
+    return PHYSFS_swapUBE64(value);
 }
 
 string Util::utf8FromUcs4(const uint32* src) {
-	string value;
-	std::size_t length = strlen((char*) src);
-	char * buffer = new char[length]; // will be smaller than len
-	PHYSFS_utf8FromUcs4(src, buffer, length);
-	value.append(buffer);
-	return value;
+    string value;
+    std::size_t length = strlen((char*)src);
+    char* buffer = new char[length]; // will be smaller than len
+    PHYSFS_utf8FromUcs4(src, buffer, length);
+    value.append(buffer);
+    return value;
 }
 
 string Util::utf8ToUcs4(const char* src) {
-	string value;
-	std::size_t length = strlen(src) * 4;
-	char * buffer = new char[length]; // will be smaller than len
-	PHYSFS_utf8ToUcs4(src, (uint32*) buffer, length);
-	value.append(buffer);
-	return value;
+    string value;
+    std::size_t length = strlen(src) * 4;
+    char* buffer = new char[length]; // will be smaller than len
+    PHYSFS_utf8ToUcs4(src, (uint32*)buffer, length);
+    value.append(buffer);
+    return value;
 }
 
 string Util::utf8FromUcs2(const uint16* src) {
-	string value;
-	std::size_t length = strlen((char*) src);
-	char * buffer = new char[length]; // will be smaller than len
-	PHYSFS_utf8FromUcs2(src, buffer, length);
-	value.append(buffer);
-	return value;
+    string value;
+    std::size_t length = strlen((char*)src);
+    char* buffer = new char[length]; // will be smaller than len
+    PHYSFS_utf8FromUcs2(src, buffer, length);
+    value.append(buffer);
+    return value;
 }
 
 string Util::utf8ToUcs2(const char* src) {
-	string value;
-	std::size_t length = strlen(src) * 2;
-	char * buffer = new char[length]; // will be smaller than len
-	PHYSFS_utf8ToUcs2(src, (uint16*) buffer, length);
-	value.append(buffer);
-	return value;
+    string value;
+    std::size_t length = strlen(src) * 2;
+    char* buffer = new char[length]; // will be smaller than len
+    PHYSFS_utf8ToUcs2(src, (uint16*)buffer, length);
+    value.append(buffer);
+    return value;
 }
 
 string Util::utf8FromLatin1(const char* src) {
-	string value;
-	std::size_t length = strlen((char*) src) * 2;
-	char * buffer = new char[length]; // will be smaller than len
-	PHYSFS_utf8FromLatin1(src, buffer, length);
-	value.append(buffer);
-	return value;
+    string value;
+    std::size_t length = strlen((char*)src) * 2;
+    char* buffer = new char[length]; // will be smaller than len
+    PHYSFS_utf8FromLatin1(src, buffer, length);
+    value.append(buffer);
+    return value;
 }
 
 }


### PR DESCRIPTION
Fix corrupted output when writing to stream due to incorrect buffer pointer handling.  This will fix the issue described in #9